### PR TITLE
#63 Retain entry class information when processing @SourceStreams and @SinkStreams annotations

### DIFF
--- a/sdk/src/test/java/co/decodable/sdk/pipeline/internal/config/metadata/MetadataProcessorTest.java
+++ b/sdk/src/test/java/co/decodable/sdk/pipeline/internal/config/metadata/MetadataProcessorTest.java
@@ -9,9 +9,9 @@ package co.decodable.sdk.pipeline.internal.config.metadata;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import co.decodable.sdk.pipeline.internal.metadata.MetadataProcessor;
-import com.google.common.io.CharSource;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
@@ -19,46 +19,60 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class MetadataProcessorTest {
 
   private static final String OUTPUT_PATH = "META-INF/decodable/stream-names.properties";
+  private static final String SOURCES_AND_SINKS_FILE_PATH =
+      "./src/test/java/co/decodable/sdk/pipeline/snippets/PurchaseOrderProcessingJob.java";
+  private static final String ONLY_SOURCES_FILE_PATH =
+      "./src/test/java/co/decodable/sdk/pipeline/snippets/DummySourcesOnlyJob.java";
+  private static final String ONLY_SINKS_FILE_PATH =
+      "./src/test/java/co/decodable/sdk/pipeline/snippets/DummySinksOnlyJob.java";
 
   @Test
-  public void shouldGenerateStreamNamesFile() throws MalformedURLException {
-    URL jobFile =
-        new File(
-                "./src/test/java/co/decodable/sdk/pipeline/snippets/PurchaseOrderProcessingJob.java")
-            .toURI()
-            .toURL();
+  public void shouldGenerateStreamNamesFile() throws IOException {
+    URL jobFile1 = new File(SOURCES_AND_SINKS_FILE_PATH).toURI().toURL();
+    URL jobFile2 = new File(ONLY_SOURCES_FILE_PATH).toURI().toURL();
+    URL jobFile3 = new File(ONLY_SINKS_FILE_PATH).toURI().toURL();
 
-    Compilation compilation = compile(jobFile);
+    Compilation compilation = compile(jobFile1, jobFile2, jobFile3);
 
     assertThat(compilation).succeeded();
-    assertThat(compilation)
-        .generatedFile(StandardLocation.CLASS_OUTPUT, OUTPUT_PATH)
-        .hasContents(
-            CharSource.wrap(
-                    "source-streams=purchase-orders\nsink-streams=purchase-orders-processed\n")
-                .asByteSource(StandardCharsets.UTF_8));
+    var file = compilation.generatedFile(StandardLocation.CLASS_OUTPUT, OUTPUT_PATH).get();
+    var fileContents = file.getCharContent(false).toString();
+    assertThat(fileContents)
+        .startsWith("source-streams:\n")
+        .contains("\nsink-streams:\n")
+        .hasLineCount(6)
+        .contains(
+            "\nco.decodable.sdk.pipeline.snippets.PurchaseOrderProcessingJob=purchase-orders\n")
+        .contains(
+            "\nco.decodable.sdk.pipeline.snippets.PurchaseOrderProcessingJob=purchase-orders-processed\n")
+        .containsPattern(
+            Pattern.compile(
+                "\\nco.decodable.sdk.pipeline.snippets.DummySourcesOnlyJob=source[1-2],source[1-2]\\n"))
+        .containsPattern(
+            Pattern.compile(
+                "\\nco.decodable.sdk.pipeline.snippets.DummySinksOnlyJob=sink[1-2],sink[1-2]$"));
   }
 
   @Test
   public void onlySourcesPresent() throws IOException {
-    URL jobFile =
-        new File("./src/test/java/co/decodable/sdk/pipeline/snippets/DummySourcesOnlyJob.java")
-            .toURI()
-            .toURL();
+    URL jobFile = new File(ONLY_SOURCES_FILE_PATH).toURI().toURL();
 
     Compilation compilation = compile(jobFile);
 
@@ -66,17 +80,17 @@ public class MetadataProcessorTest {
     var file = compilation.generatedFile(StandardLocation.CLASS_OUTPUT, OUTPUT_PATH).get();
     var fileContents = file.getCharContent(false).toString();
     assertThat(fileContents)
-        .endsWith("\nsink-streams=\n")
-        .hasLineCount(2)
-        .containsPattern(Pattern.compile("^source-streams=source[1-2],source[1-2]\\n"));
+        .startsWith("source-streams:\n")
+        .endsWith("\nsink-streams:\n")
+        .hasLineCount(3)
+        .containsPattern(
+            Pattern.compile(
+                "\\nco.decodable.sdk.pipeline.snippets.DummySourcesOnlyJob=source[1-2],source[1-2]\\n"));
   }
 
   @Test
   public void onlySinksPresent() throws IOException {
-    URL jobFile =
-        new File("./src/test/java/co/decodable/sdk/pipeline/snippets/DummySinksOnlyJob.java")
-            .toURI()
-            .toURL();
+    URL jobFile = new File(ONLY_SINKS_FILE_PATH).toURI().toURL();
 
     Compilation compilation = compile(jobFile);
 
@@ -84,9 +98,11 @@ public class MetadataProcessorTest {
     var file = compilation.generatedFile(StandardLocation.CLASS_OUTPUT, OUTPUT_PATH).get();
     var fileContents = file.getCharContent(false).toString();
     assertThat(fileContents)
-        .startsWith("source-streams=\n")
-        .hasLineCount(2)
-        .containsPattern(Pattern.compile("\\nsink-streams=sink[1-2],sink[1-2]$"));
+        .startsWith("source-streams:\nsink-streams:\n")
+        .hasLineCount(3)
+        .containsPattern(
+            Pattern.compile(
+                "\\nco.decodable.sdk.pipeline.snippets.DummySinksOnlyJob=sink[1-2],sink[1-2]$"));
   }
 
   @Test
@@ -110,10 +126,25 @@ public class MetadataProcessorTest {
     assertThat(record.getMessage()).contains("Neither source nor sink streams were declared");
   }
 
-  private static Compilation compile(URL fileWithoutAnnotations) {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "./src/test/java/co/decodable/sdk/pipeline/snippets/EnumWithSourceStreamsAnnotation.java",
+        "./src/test/java/co/decodable/sdk/pipeline/snippets/InterfaceWithSourceStreamsAnnotation.java"
+      })
+  public void shouldThrowIfAnnotationIsUsedOnWrongType(String filePath)
+      throws MalformedURLException {
+    assertThatThrownBy(() -> compile(new File(filePath).toURI().toURL()))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(
+            "@SourceStreams and @SinkStreams annotations can only be used at class level");
+  }
+
+  private static Compilation compile(URL... fileURLs) {
     return Compiler.javac()
         .withProcessors(new MetadataProcessor())
-        .compile(JavaFileObjects.forResource(fileWithoutAnnotations));
+        .compile(
+            Arrays.stream(fileURLs).map(JavaFileObjects::forResource).collect(Collectors.toList()));
   }
 
   private static class TestHandler extends Handler {

--- a/sdk/src/test/java/co/decodable/sdk/pipeline/snippets/EnumWithSourceStreamsAnnotation.java
+++ b/sdk/src/test/java/co/decodable/sdk/pipeline/snippets/EnumWithSourceStreamsAnnotation.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Decodable, Inc.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package co.decodable.sdk.pipeline.snippets;
+
+import co.decodable.sdk.pipeline.metadata.SourceStreams;
+
+@SourceStreams(EnumWithSourceStreamsAnnotation.STREAM_NAME)
+public enum EnumWithSourceStreamsAnnotation {
+  ENUM_VALUE;
+
+  static final String STREAM_NAME = "stream-name";
+}

--- a/sdk/src/test/java/co/decodable/sdk/pipeline/snippets/InterfaceWithSourceStreamsAnnotation.java
+++ b/sdk/src/test/java/co/decodable/sdk/pipeline/snippets/InterfaceWithSourceStreamsAnnotation.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Decodable, Inc.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package co.decodable.sdk.pipeline.snippets;
+
+import static co.decodable.sdk.pipeline.snippets.InterfaceWithSourceStreamsAnnotation.STREAM_NAME;
+
+import co.decodable.sdk.pipeline.metadata.SourceStreams;
+
+@SourceStreams(STREAM_NAME)
+public interface InterfaceWithSourceStreamsAnnotation {
+  String STREAM_NAME = "stream-name";
+}


### PR DESCRIPTION
Source and sink stream information is not persisted in the metadata file per entry class

Fixes https://github.com/decodableco/decodable-pipeline-sdk/issues/63

@jmahonin I need to nail down a few details regarding the interaction with out internal services. I've converted this to draft, will ping you when I think it's ready and will work well with relevant other services.