### PR TITLE
DE-7613: Handle sensitive stream credentials in Pipeline SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ bin
 # VSCode
 .vscode
 
+# IntelliJ
+.idea
+*.iml
+
 # Apache Maven
 dependency-reduced-pom.xml
 target

--- a/sdk/src/main/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMapping.java
+++ b/sdk/src/main/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMapping.java
@@ -10,15 +10,27 @@ package co.decodable.sdk.pipeline.internal.config;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class StreamConfigMapping {
 
   private static final Pattern KEY_PATTERN = Pattern.compile("DECODABLE_STREAM_CONFIG_(.*)");
+  private static final Set<String> SECRET_PROPERTY_KEYS =
+      Set.of(
+          "properties.ssl.keystore.key",
+          "properties.ssl.key.password",
+          "properties.ssl.truststore.password",
+          "properties.sasl.jaas.config",
+          "properties.ssl.truststore.certificates",
+          "properties.ssl.keystore.certificate.chain");
 
   private final Map<String, StreamConfig> configsByStreamName = new HashMap<>();
   private final Map<String, StreamConfig> configsByStreamId = new HashMap<>();
@@ -31,22 +43,39 @@ public class StreamConfigMapping {
       if (keyMatcher.matches()) {
         String streamId = keyMatcher.group(1);
 
+        Map<String, Object> config;
         try {
-          Map<String, Object> config =
-              mapper.readValue(entry.getValue(), new TypeReference<Map<String, Object>>() {});
-          String streamName = (String) config.get("name");
-
-          @SuppressWarnings("unchecked")
-          StreamConfig streamConfig =
-              new StreamConfig(
-                  streamId, streamName, (Map<String, String>) config.get("properties"));
-          configsByStreamId.put(streamId, streamConfig);
-          configsByStreamName.put(streamName, streamConfig);
+          config = mapper.readValue(entry.getValue(), new TypeReference<Map<String, Object>>() {});
         } catch (JsonProcessingException e) {
           throw new IllegalArgumentException(
               String.format("Couldn't parse stream configuration env variable %s", entry.getKey()),
               e);
         }
+
+        String streamName = (String) config.get("name");
+        Map<String, Object> properties = (Map<String, Object>) config.get("properties");
+
+        for (String secretKey : SECRET_PROPERTY_KEYS) {
+          properties.computeIfPresent(
+              secretKey,
+              (k, v) -> {
+                try {
+                  return Files.readString(Paths.get((String) v));
+                } catch (IOException e) {
+                  throw new IllegalArgumentException(
+                      String.format(
+                          "Could not read secret property key %s from path %s",
+                          secretKey, (String) v),
+                      e);
+                }
+              });
+        }
+
+        @SuppressWarnings("unchecked")
+        StreamConfig streamConfig =
+            new StreamConfig(streamId, streamName, (Map<String, String>) config.get("properties"));
+        configsByStreamId.put(streamId, streamConfig);
+        configsByStreamName.put(streamName, streamConfig);
       }
     }
   }


### PR DESCRIPTION
For environments where internal Kafka authentication is using mTLS or SASL, the credentials would be exposed in plaintext in an environment variable, which isn't ideal from a security perspective.

With this change, any keys in DECODABLE_STREAM_CONFIG_<id> matching `SECRET_PROPERTY_KEYS` will use the provided value as a file path, rather than a literal value.

This allows for providing secret credentials as a mounted location, rather than passing them in an environment variable.

