### PR TITLE
 #69 Handle sensitive stream credentials in Pipeline SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ bin
 # VSCode
 .vscode
 
+# IntelliJ
+.idea
+*.iml
+
 # Apache Maven
 dependency-reduced-pom.xml
 target

--- a/sdk/src/main/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMapping.java
+++ b/sdk/src/main/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMapping.java
@@ -10,15 +10,28 @@ package co.decodable.sdk.pipeline.internal.config;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class StreamConfigMapping {
 
   private static final Pattern KEY_PATTERN = Pattern.compile("DECODABLE_STREAM_CONFIG_(.*)");
+  private static final Set<String> SECRET_PROPERTY_KEYS =
+      Set.of(
+          "properties.ssl.keystore.key",
+          "properties.ssl.key.password",
+          "properties.ssl.truststore.password",
+          "properties.sasl.jaas.config",
+          "properties.sasl.mechanism",
+          "properties.ssl.truststore.certificates",
+          "properties.ssl.keystore.certificate.chain");
 
   private final Map<String, StreamConfig> configsByStreamName = new HashMap<>();
   private final Map<String, StreamConfig> configsByStreamId = new HashMap<>();
@@ -31,22 +44,37 @@ public class StreamConfigMapping {
       if (keyMatcher.matches()) {
         String streamId = keyMatcher.group(1);
 
+        Map<String, Object> config;
         try {
-          Map<String, Object> config =
-              mapper.readValue(entry.getValue(), new TypeReference<Map<String, Object>>() {});
-          String streamName = (String) config.get("name");
-
-          @SuppressWarnings("unchecked")
-          StreamConfig streamConfig =
-              new StreamConfig(
-                  streamId, streamName, (Map<String, String>) config.get("properties"));
-          configsByStreamId.put(streamId, streamConfig);
-          configsByStreamName.put(streamName, streamConfig);
+          config = mapper.readValue(entry.getValue(), new TypeReference<Map<String, Object>>() {});
         } catch (JsonProcessingException e) {
           throw new IllegalArgumentException(
               String.format("Couldn't parse stream configuration env variable %s", entry.getKey()),
               e);
         }
+
+        String streamName = (String) config.get("name");
+        Map<String, Object> properties = (Map<String, Object>) config.get("properties");
+
+        for (String secretKey : SECRET_PROPERTY_KEYS) {
+          properties.computeIfPresent(
+              secretKey,
+              (k, v) -> {
+                try {
+                  // Attempt to read the secret property from a file
+                  // For backwards compatibility, use the property value if the file doesn't exist
+                  return Files.readString(Paths.get((String) v));
+                } catch (IOException e) {
+                  return (String) v;
+                }
+              });
+        }
+
+        @SuppressWarnings("unchecked")
+        StreamConfig streamConfig =
+            new StreamConfig(streamId, streamName, (Map<String, String>) config.get("properties"));
+        configsByStreamId.put(streamId, streamConfig);
+        configsByStreamName.put(streamName, streamConfig);
       }
     }
   }

--- a/sdk/src/test/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMappingTest.java
+++ b/sdk/src/test/java/co/decodable/sdk/pipeline/internal/config/StreamConfigMappingTest.java
@@ -12,6 +12,10 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import co.decodable.sdk.pipeline.StartupMode;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -58,5 +62,45 @@ public class StreamConfigMappingTest {
             entry("isolation.level", "read_committed"),
             entry("compression.type", "zstd"),
             entry("enable.idempotence", "true"));
+  }
+
+  @Test
+  public void shouldHandleSecretProperties() throws IOException {
+    String secretData = "secret-data";
+    Path secretPath = Files.createTempFile("sdk-test-secret", null);
+    Files.write(secretPath, secretData.getBytes(StandardCharsets.UTF_8));
+
+    String mechanism = "SCRAM-SHA-512";
+    String config =
+        "{\n"
+            + "    \"properties\": {\n"
+            + "        \"value.format\": \"debezium-json\",\n"
+            + "        \"key.format\": \"json\",\n"
+            + "        \"topic\": \"stream-00000000-078fc8b5\",\n"
+            + "        \"scan.startup.mode\": \"latest-offset\",\n"
+            + "        \"key.fields\": \"\\\"shipment_id\\\"\",\n"
+            + "        \"sink.transactional-id-prefix\": \"tx-account-00000000-PIPELINE-af78c091-1686579235527\",\n"
+            + "        \"sink.delivery-guarantee\": \"exactly-once\",\n"
+            + "        \"properties.bootstrap.servers\": \"my-kafka:9092\",\n"
+            + "        \"properties.transaction.timeout.ms\": \"900000\",\n"
+            + "        \"properties.isolation.level\": \"read_committed\",\n"
+            + "        \"properties.compression.type\": \"zstd\",\n"
+            + "        \"properties.enable.idempotence\": \"true\",\n"
+            + "        \"properties.sasl.jaas.mechanism\": \""
+            + mechanism
+            + "\",\n"
+            + "        \"properties.sasl.jaas.config\": \""
+            + secretPath
+            + "\"\n"
+            + "    },\n"
+            + "    \"name\": \"shipments\"\n"
+            + "}";
+
+    StreamConfigMapping streamConfigMapping =
+        new StreamConfigMapping(Map.of("DECODABLE_STREAM_CONFIG_078fc8b5", config));
+    StreamConfig streamConfig = streamConfigMapping.determineConfig(null, "078fc8b5");
+
+    assertEquals(secretData, streamConfig.kafkaProperties().get("sasl.jaas.config"));
+    assertEquals(mechanism, streamConfig.kafkaProperties().get("sasl.jaas.mechanism"));
   }
 }


### PR DESCRIPTION
For environments where internal Kafka authentication is using mTLS or SASL, the credentials would be exposed in plaintext in an environment variable, which isn't ideal from a security perspective.

With this change, any keys in DECODABLE_STREAM_CONFIG_ matching SECRET_PROPERTY_KEYS will use the provided value as a file path, rather than a literal value.

This allows for providing secret credentials as a mounted location, rather than passing them in an environment variable.