### PR TITLE
DE-8810: Pipeline SDK shouldn't mark kafka as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           sed -i 's/kafkaConnectorVersion = \x27.*\x27/kafkaConnectorVersion = \x27'"$KAFKA_CONNECTOR_VERSION"'\x27/g' examples/custom-pipelines-hello-world/build.gradle
 
       - name: Build SDK
-        run: cd sdk/${{ matrix.value }} && ../gradlew build publishToMavenLocal
+        run: cd sdk/${{ matrix.value.project-dir }} && ../gradlew build publishToMavenLocal
 
       - name: Build example project with Maven
         run: cd examples/custom-pipelines-hello-world && ./mvnw -B clean verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        value: [flink-1.16,flink-1.18,flink-1.19,flink-1.20]
+        value: [{flink: 1.16.3, kafka-connector: 1.16.3},{flink: 1.18.1, kafka-connector: 3.2.0-1.18},{flink: 1.19.2, kafka-connector: 3.3.0-1.19},{flink: 1.20.1, kafka-connector: 3.4.0-1.20}]
 
     steps:
       - name: 'Check out repository'
@@ -45,7 +45,8 @@ jobs:
         id: version
         run: |
           RELEASE_VERSION="1.0.0.ci"
-          FLINK_VERSION=`cd sdk/${{ matrix.value }} && grep "def flinkVersion" build.gradle | sed "s/.*'\([0-9.]*\)'.*/\1/"`
+          FLINK_VERSION=${{ matrix.value.flink }}
+          KAFKA_CONNECTOR_VERSION=${{ matrix.value.kafka-connector }}
           
           echo "version=$FLINK_VERSION-$RELEASE_VERSION" > sdk/${{ matrix.value }}/gradle.properties
           sed -i 's/<decodable.pipeline.sdk.version>.*<\/decodable.pipeline.sdk.version>/<decodable.pipeline.sdk.version>'"$FLINK_VERSION-$RELEASE_VERSION"'<\/decodable.pipeline.sdk.version>/g' examples/custom-pipelines-hello-world/pom.xml
@@ -53,6 +54,9 @@ jobs:
 
           sed -i 's/<flink.version>.*<\/flink.version>/<flink.version>'"$FLINK_VERSION"'<\/flink.version>/g' examples/custom-pipelines-hello-world/pom.xml
           sed -i 's/flinkVersion = \x27.*\x27/flinkVersion = \x27'"$FLINK_VERSION"'\x27/g' examples/custom-pipelines-hello-world/build.gradle
+
+          sed -i 's/<flink.kafka.connector.version>.*<\/flink.kafka.connector.version>/<flink.kafka.connector.version>'"$KAFKA_CONNECTOR_VERSION"'<\/flink.kafka.connector.version>/g' examples/custom-pipelines-hello-world/pom.xml
+          sed -i 's/kafkaConnectorVersion = \x27.*\x27/kafkaConnectorVersion = \x27'"$KAFKA_CONNECTOR_VERSION"'\x27/g' examples/custom-pipelines-hello-world/build.gradle
 
       - name: Build SDK
         run: cd sdk/${{ matrix.value }} && ../gradlew build publishToMavenLocal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        value: [{flink: 1.16.3, kafka-connector: 1.16.3},{flink: 1.18.1, kafka-connector: 3.2.0-1.18},{flink: 1.19.2, kafka-connector: 3.3.0-1.19},{flink: 1.20.1, kafka-connector: 3.4.0-1.20}]
+        value: [{flink: 1.16.3, kafka-connector: 1.16.3, project-dir: flink-1.16},{flink: 1.18.1, kafka-connector: 3.2.0-1.18, project-dir: flink-1.18},{flink: 1.19.2, kafka-connector: 3.3.0-1.19, project-dir: flink-1.19},{flink: 1.20.1, kafka-connector: 3.4.0-1.20, project-dir: flink-1.20}]
 
     steps:
       - name: 'Check out repository'
@@ -48,7 +48,7 @@ jobs:
           FLINK_VERSION=${{ matrix.value.flink }}
           KAFKA_CONNECTOR_VERSION=${{ matrix.value.kafka-connector }}
           
-          echo "version=$FLINK_VERSION-$RELEASE_VERSION" > sdk/${{ matrix.value }}/gradle.properties
+          echo "version=$FLINK_VERSION-$RELEASE_VERSION" > sdk/${{ matrix.value.project-dir }}/gradle.properties
           sed -i 's/<decodable.pipeline.sdk.version>.*<\/decodable.pipeline.sdk.version>/<decodable.pipeline.sdk.version>'"$FLINK_VERSION-$RELEASE_VERSION"'<\/decodable.pipeline.sdk.version>/g' examples/custom-pipelines-hello-world/pom.xml
           sed -i 's/sdkVersion = \x27.*\x27/sdkVersion = \x27'"$FLINK_VERSION-$RELEASE_VERSION"'\x27/g' examples/custom-pipelines-hello-world/build.gradle
 

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -67,8 +67,7 @@ dependencies {
     excludeFromShadow "org.apache.flink:flink-table-runtime:$flinkVersion"
 
     testImplementation "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
-    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
-    testImplementation "org.apache.kafka:kafka-clients:3.4.0"
+    testImplementation "commons-codec:commons-codec:1.18.0"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -31,21 +31,42 @@ application {
     mainClass = 'co.decodable.examples.cpdemo.DataStreamJob'
 }
 
+configurations {
+    // Dependencies which are provided by Flink at runtime should be excluded from the uber JAR.
+    // We use a custom configuration for this, which is similar to compileOnly except that we exclude it from
+    // shadowJar further down
+    excludeFromShadow
+}
+
+tasks.withType(JavaCompile).configureEach {
+    // Include the excludeFromShadow configuration in the compile classpath
+    classpath += configurations.excludeFromShadow
+}
+
+tasks.withType(Javadoc).configureEach {
+    // Include the excludeFromShadow configuration in the compile classpath
+    classpath += configurations.excludeFromShadow
+}
+
 dependencies {
     annotationProcessor "co.decodable:decodable-pipeline-sdk:$sdkVersion"
 
     implementation "co.decodable:decodable-pipeline-sdk:$sdkVersion"
-    implementation "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation "org.apache.flink:flink-json:$flinkVersion"
 
-    compileOnly "org.apache.flink:flink-streaming-java:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-api-java:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-planner_2.12:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-common:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-runtime:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
+    excludeFromShadow "org.apache.flink:flink-streaming-java:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-table-api-java:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-table-planner_2.12:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-table-common:$flinkVersion"
+    excludeFromShadow "org.apache.flink:flink-table-runtime:$flinkVersion"
 
+    // Kafka connector is bundled with the Flink image used by Decodable
+    testImplementation "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
+    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+    testImplementation "org.apache.kafka:kafka-clients:3.4.0"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"
@@ -73,18 +94,10 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-configurations {
-    // compileOnly-scoped dependencies should be excluded from the uber JAR,
-    // but the compileOnly scope is not allowed to be resolved by Gradle.
-    // so we're deriving a configuration from it which we actually can resolve.
-    provided
-    provided.extendsFrom compileOnly
-}
-
 shadowJar {
   def exclude_modules = project
             .configurations
-            .provided
+            .excludeFromShadow
             .resolvedConfiguration
             .getLenientConfiguration()
             .getAllModuleDependencies()

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -17,6 +17,7 @@ version = '0.2'
 
 ext {
     flinkVersion = '1.20.1'
+    kafkaConnectorVersion = '3.4.0-1.20.1'
     log4jVersion = '2.17.1'
     sdkVersion = '1.20.1-1.0.0.Beta8'
 }
@@ -34,6 +35,7 @@ dependencies {
     annotationProcessor "co.decodable:decodable-pipeline-sdk:$sdkVersion"
 
     implementation "co.decodable:decodable-pipeline-sdk:$sdkVersion"
+    implementation "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation "org.apache.flink:flink-json:$flinkVersion"
 

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -17,7 +17,7 @@ version = '0.2'
 
 ext {
     flinkVersion = '1.20.1'
-    kafkaConnectorVersion = '3.4.0-1.20.1'
+    kafkaConnectorVersion = '3.4.0-1.20'
     log4jVersion = '2.17.1'
     sdkVersion = '1.20.1-1.0.0.Beta8'
 }

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -33,8 +33,8 @@ application {
 
 configurations {
     // Dependencies which are provided by Flink at runtime should be excluded from the uber JAR.
-    // We use a custom configuration for this, which is similar to compileOnly except that we exclude it from
-    // shadowJar further down
+    // We use a custom configuration for this, which is similar to compileOnly except that we exclude these AND THEIR
+    // TRANSITIVE DEPENDENCIES from shadowJar further down
     excludeFromShadow
 }
 
@@ -55,7 +55,9 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation "org.apache.flink:flink-json:$flinkVersion"
 
-    excludeFromShadow "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
+    // Transitive dependencies of this should NOT be excluded (they contain Jackson, for instance)
+    compileOnly "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
+
     excludeFromShadow "org.apache.flink:flink-streaming-java:$flinkVersion"
     excludeFromShadow "org.apache.flink:flink-table-api-java:$flinkVersion"
     excludeFromShadow "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/examples/custom-pipelines-hello-world/build.gradle
+++ b/examples/custom-pipelines-hello-world/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation "org.apache.flink:flink-json:$flinkVersion"
 
+    // Kafka connector is bundled with the Flink image used by Decodable
     // Transitive dependencies of this should NOT be excluded (they contain Jackson, for instance)
     compileOnly "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
 
@@ -65,7 +66,6 @@ dependencies {
     excludeFromShadow "org.apache.flink:flink-table-common:$flinkVersion"
     excludeFromShadow "org.apache.flink:flink-table-runtime:$flinkVersion"
 
-    // Kafka connector is bundled with the Flink image used by Decodable
     testImplementation "org.apache.flink:flink-connector-kafka:$kafkaConnectorVersion"
     testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.kafka:kafka-clients:3.4.0"

--- a/examples/custom-pipelines-hello-world/pom.xml
+++ b/examples/custom-pipelines-hello-world/pom.xml
@@ -27,6 +27,7 @@
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<decodable.pipeline.sdk.version>1.20.1-1.0.0.Beta8</decodable.pipeline.sdk.version>
 		<flink.kafka.connector.version>3.4.0-1.20</flink.kafka.connector.version>
+		<aws.msk.iam.auth.version>1.1.6</aws.msk.iam.auth.version>
 		<flink.version>1.20.1</flink.version>
 		<log4j.version>2.17.1</log4j.version>
 	</properties>
@@ -36,11 +37,6 @@
 			<groupId>co.decodable</groupId>
 			<artifactId>decodable-pipeline-sdk</artifactId>
 			<version>${decodable.pipeline.sdk.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-kafka</artifactId>
-			<version>${flink.kafka.connector.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -53,6 +49,12 @@
 			<version>${flink.version}</version>
     	</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka</artifactId>
+			<version>${flink.kafka.connector.version}</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
@@ -90,6 +92,12 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>software.amazon.msk</groupId>
+			<artifactId>aws-msk-iam-auth</artifactId>
+			<version>${aws.msk.iam.auth.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients</artifactId>

--- a/examples/custom-pipelines-hello-world/pom.xml
+++ b/examples/custom-pipelines-hello-world/pom.xml
@@ -37,9 +37,9 @@
 			<version>${decodable.pipeline.sdk.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka-clients</artifactId>
-			<version>3.4.0</version>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka</artifactId>
+			<version>3.4.0-1.20</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/custom-pipelines-hello-world/pom.xml
+++ b/examples/custom-pipelines-hello-world/pom.xml
@@ -93,9 +93,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>software.amazon.msk</groupId>
-			<artifactId>aws-msk-iam-auth</artifactId>
-			<version>${aws.msk.iam.auth.version}</version>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka</artifactId>
+			<version>${flink.kafka.connector.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.18.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/examples/custom-pipelines-hello-world/pom.xml
+++ b/examples/custom-pipelines-hello-world/pom.xml
@@ -37,6 +37,11 @@
 			<version>${decodable.pipeline.sdk.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>3.4.0</version>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.15.2</version>

--- a/examples/custom-pipelines-hello-world/pom.xml
+++ b/examples/custom-pipelines-hello-world/pom.xml
@@ -26,6 +26,7 @@
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<decodable.pipeline.sdk.version>1.20.1-1.0.0.Beta8</decodable.pipeline.sdk.version>
+		<flink.kafka.connector.version>3.4.0-1.20</flink.kafka.connector.version>
 		<flink.version>1.20.1</flink.version>
 		<log4j.version>2.17.1</log4j.version>
 	</properties>
@@ -39,7 +40,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.4.0-1.20</version>
+			<version>${flink.kafka.connector.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/sdk/flink-1.16/build.gradle
+++ b/sdk/flink-1.16/build.gradle
@@ -10,10 +10,12 @@ dependencies {
     def flinkVersion = '1.16.3'
 
     api "org.apache.flink:flink-core:$flinkVersion"
-    implementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+
+    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
+    compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
 
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.16/build.gradle
+++ b/sdk/flink-1.16/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
 
+    testImplementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/sdk/flink-1.16/build.gradle
+++ b/sdk/flink-1.16/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
 
-    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    // IAM library and Kafka connector are bundled with Flink images used by Decodable
     testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"

--- a/sdk/flink-1.16/build.gradle
+++ b/sdk/flink-1.16/build.gradle
@@ -16,8 +16,6 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
 
-    // IAM library and Kafka connector are bundled with Flink images used by Decodable
-    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.16/build.gradle
+++ b/sdk/flink-1.16/build.gradle
@@ -12,11 +12,12 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
 
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
 
+    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.18/build.gradle
+++ b/sdk/flink-1.18/build.gradle
@@ -14,12 +14,14 @@ dependencies {
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
 
     // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
 
+
+    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.18/build.gradle
+++ b/sdk/flink-1.18/build.gradle
@@ -12,11 +12,13 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     //NOTE: flink-connector-base is needed as of Flink 1.18
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
-    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
-    implementation "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+
+    // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
+    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
+    compileOnly "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
 
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.18/build.gradle
+++ b/sdk/flink-1.18/build.gradle
@@ -19,8 +19,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
 
-
-    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    // IAM library and Kafka connector are bundled with Flink images used by Decodable
     testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"

--- a/sdk/flink-1.18/build.gradle
+++ b/sdk/flink-1.18/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
 
+    testImplementation "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/sdk/flink-1.18/build.gradle
+++ b/sdk/flink-1.18/build.gradle
@@ -19,8 +19,6 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
 
-    // IAM library and Kafka connector are bundled with Flink images used by Decodable
-    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:3.2.0-1.18"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.19/build.gradle
+++ b/sdk/flink-1.19/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
 
-    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    // IAM library and Kafka connector are bundled with Flink images used by Decodable
     testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"

--- a/sdk/flink-1.19/build.gradle
+++ b/sdk/flink-1.19/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
 
+    testImplementation "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/sdk/flink-1.19/build.gradle
+++ b/sdk/flink-1.19/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
 
-    // IAM library and Kafka connector are bundled with Flink images used by Decodable
-    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+    // For some reason, with Flink 1.18+, the Redpanda testcontainer requires commons-codec to be added explicitly
+    testImplementation "commons-codec:commons-codec:1.18.0"
     testImplementation "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.19/build.gradle
+++ b/sdk/flink-1.19/build.gradle
@@ -14,12 +14,13 @@ dependencies {
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
 
     // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
 
+    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.19/build.gradle
+++ b/sdk/flink-1.19/build.gradle
@@ -12,11 +12,13 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     //NOTE: flink-connector-base is needed as of Flink 1.18
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
-    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
-    implementation "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+
+    // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
+    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
+    compileOnly "org.apache.flink:flink-connector-kafka:3.3.0-1.19"
 
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.20/build.gradle
+++ b/sdk/flink-1.20/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
     compileOnly "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
 
-    // IAM library is now bundled (and shaded) with our CuPi Flink images
-    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+    // For some reason, with Flink 1.18+, the Redpanda testcontainer requires commons-codec to be added explicitly
+    testImplementation "commons-codec:commons-codec:1.18.0"
     testImplementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.20/build.gradle
+++ b/sdk/flink-1.20/build.gradle
@@ -12,15 +12,11 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     //NOTE: flink-connector-base is needed as of Flink 1.18
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
+    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
+    implementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
-
-    // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
-    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
-    compileOnly "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
-
-    testImplementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
 
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.20/build.gradle
+++ b/sdk/flink-1.20/build.gradle
@@ -12,11 +12,15 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     //NOTE: flink-connector-base is needed as of Flink 1.18
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
-    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
-    implementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+
+    // NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
+    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
+    compileOnly "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
+
+    testImplementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
 
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"

--- a/sdk/flink-1.20/build.gradle
+++ b/sdk/flink-1.20/build.gradle
@@ -16,8 +16,9 @@ dependencies {
     implementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
 
+    // IAM library is now bundled (and shaded) with our CuPi Flink images
+    testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"

--- a/sdk/flink-1.20/build.gradle
+++ b/sdk/flink-1.20/build.gradle
@@ -12,13 +12,16 @@ dependencies {
     api "org.apache.flink:flink-core:$flinkVersion"
     //NOTE: flink-connector-base is needed as of Flink 1.18
     implementation "org.apache.flink:flink-connector-base:$flinkVersion"
-    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
-    implementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     implementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
+    //NOTE: flink-connector-kafka released with different versioning schema starting with Flink 1.18
+    // A Kafka connector with custom patches is supplied by the Decodable platform at runtime
+    compileOnly "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
+
     // IAM library is now bundled (and shaded) with our CuPi Flink images
     testImplementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+    testImplementation "org.apache.flink:flink-connector-kafka:3.4.0-1.20"
     testImplementation "org.apache.flink:flink-clients:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"


### PR DESCRIPTION
**Note**: Before we create a release with this change, we need to release new Flink images that actually bundle our Kafka connector fork, and document the changes