### PR TITLE
deprecate .withStreamId(...) methods for source/sink builders

### DIFF
--- a/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
+++ b/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 @Incubating
 public interface DecodableStreamSinkBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to write to. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to write to. */
   DecodableStreamSinkBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to write to. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to write to. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSinkBuilder<T> withStreamId(String streamId);
 
   /** Specifies the serialization schema to be used. */

--- a/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
+++ b/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 @Incubating
 public interface DecodableStreamSourceBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to read from. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to read from. */
   DecodableStreamSourceBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to read from. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to read from. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSourceBuilder<T> withStreamId(String streamId);
 
   /** Specifies the start-up mode to use when reading from the stream. */

--- a/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
+++ b/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
@@ -33,6 +33,7 @@ public class DecodableStreamSinkBuilderImpl<T> implements DecodableStreamSinkBui
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSinkBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
+++ b/sdk/flink-1.16/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
@@ -35,6 +35,7 @@ public class DecodableStreamSourceBuilderImpl<T> implements DecodableStreamSourc
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSourceBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
+++ b/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 @Incubating
 public interface DecodableStreamSinkBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to write to. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to write to. */
   DecodableStreamSinkBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to write to. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to write to. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSinkBuilder<T> withStreamId(String streamId);
 
   /** Specifies the serialization schema to be used. */

--- a/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
+++ b/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 @Incubating
 public interface DecodableStreamSourceBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to read from. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to read from. */
   DecodableStreamSourceBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to read from. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to read from. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSourceBuilder<T> withStreamId(String streamId);
 
   /** Specifies the start-up mode to use when reading from the stream. */

--- a/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
+++ b/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
@@ -33,6 +33,7 @@ public class DecodableStreamSinkBuilderImpl<T> implements DecodableStreamSinkBui
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSinkBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
+++ b/sdk/flink-1.18/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
@@ -35,6 +35,7 @@ public class DecodableStreamSourceBuilderImpl<T> implements DecodableStreamSourc
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSourceBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
+++ b/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 @Incubating
 public interface DecodableStreamSinkBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to write to. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to write to. */
   DecodableStreamSinkBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to write to. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to write to. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSinkBuilder<T> withStreamId(String streamId);
 
   /** Specifies the serialization schema to be used. */

--- a/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
+++ b/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 @Incubating
 public interface DecodableStreamSourceBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to read from. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to read from. */
   DecodableStreamSourceBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to read from. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to read from. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSourceBuilder<T> withStreamId(String streamId);
 
   /** Specifies the start-up mode to use when reading from the stream. */

--- a/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
+++ b/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
@@ -33,6 +33,7 @@ public class DecodableStreamSinkBuilderImpl<T> implements DecodableStreamSinkBui
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSinkBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
+++ b/sdk/flink-1.19/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
@@ -35,6 +35,7 @@ public class DecodableStreamSourceBuilderImpl<T> implements DecodableStreamSourc
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSourceBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
+++ b/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSinkBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 @Incubating
 public interface DecodableStreamSinkBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to write to. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to write to. */
   DecodableStreamSinkBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to write to. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to write to. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSinkBuilder<T> withStreamId(String streamId);
 
   /** Specifies the serialization schema to be used. */

--- a/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
+++ b/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/DecodableStreamSourceBuilder.java
@@ -14,16 +14,14 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 @Incubating
 public interface DecodableStreamSourceBuilder<T> {
 
-  /**
-   * Specifies the name of the stream to read from. Either this or {@link #withStreamId(String)} may
-   * be used, but not both.
-   */
+  /** Specifies the name of the stream to read from. */
   DecodableStreamSourceBuilder<T> withStreamName(String streamName);
 
   /**
-   * Specifies the id of the stream to read from. Either this or {@link #withStreamName(String)} may
-   * be used, but not both.
+   * @deprecated Specifies the id of the stream to read from. Use {@link #withStreamName(String)}
+   *     instead.
    */
+  @Deprecated
   DecodableStreamSourceBuilder<T> withStreamId(String streamId);
 
   /** Specifies the start-up mode to use when reading from the stream. */

--- a/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
+++ b/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSinkBuilderImpl.java
@@ -33,6 +33,7 @@ public class DecodableStreamSinkBuilderImpl<T> implements DecodableStreamSinkBui
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSinkBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;

--- a/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
+++ b/sdk/flink-1.20/src/main/java/co/decodable/sdk/pipeline/internal/DecodableStreamSourceBuilderImpl.java
@@ -35,6 +35,7 @@ public class DecodableStreamSourceBuilderImpl<T> implements DecodableStreamSourc
   }
 
   @Override
+  @Deprecated
   public DecodableStreamSourceBuilder<T> withStreamId(String streamId) {
     this.streamId = streamId;
     return this;


### PR DESCRIPTION
- fixes #47