### PR TITLE
fix maven central publishing for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
         required: false
 
 env:
+  JAVA_VERSION: '11'
   JAVA_DISTRO: 'temurin'
 
 jobs:
@@ -33,9 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: ${{ env.JAVA_DISTRO }}
-          java-version: |
-             11
-             21
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2
@@ -114,8 +113,8 @@ jobs:
 
       - name: Release SDK
         env:
-          JRELEASER_NEXUS2_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.RELEASE_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.RELEASE_GPG_SECRET_KEY }}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -142,14 +142,10 @@ jreleaser {
     }
     deploy {
         maven {
-            nexus2 {
-                'maven-central' {
+            mavenCentral {
+                sonatype {
                     active = 'ALWAYS'
-                    url = 'https://s01.oss.sonatype.org/service/local'
-                    snapshotUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots'
-                    closeRepository = true
-                    releaseRepository = true
-                    sign = true
+                    url = 'https://central.sonatype.com/api/v1/publisher'
                     //NOTE: staging repositories added dynamically see below
                 }
             }
@@ -158,7 +154,7 @@ jreleaser {
 
     // adding all staging-deploy directories from subprojects
     subprojects.each { p ->
-        jreleaser.deploy.maven.nexus2.'maven-central'.stagingRepository("${p.buildDir}/staging-deploy")
+        jreleaser.deploy.maven.mavenCentral.sonatype.stagingRepository("${p.buildDir}/staging-deploy")
     }
 
     release {

--- a/sdk/settings.gradle
+++ b/sdk/settings.gradle
@@ -21,7 +21,7 @@
         id 'eclipse'
         id 'com.diffplug.spotless' version '6.25.0'
         id 'maven-publish'
-        id 'org.jreleaser' version '1.10.0'
+        id 'org.jreleaser' version '1.19.0'
     }
 
 }


### PR DESCRIPTION
* introduced changes are required now that ossrh / nexus2 has been sunset 
(see here https://central.sonatype.org/pages/ossrh-eol/)
* java version is fixed to 11 for releasing
* jreleaser plugin upgraded
* added GH repo secrets for maven central publishing and swapped entries in config
